### PR TITLE
Glob solution to Resolve #64

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,12 +5,15 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "obsidian-checklist-plugin",
       "version": "1.2.2",
       "license": "MIT",
       "dependencies": {
         "@rollup/plugin-json": "^4.1.0",
         "@types/markdown-it": "^12.0.1",
+        "@types/picomatch": "^2.3.0",
         "markdown-it": "^12.0.6",
+        "picomatch": "^2.3.0",
         "svelte": "^3.38.2"
       },
       "devDependencies": {
@@ -19,7 +22,7 @@
         "@rollup/plugin-typescript": "^6.0.0",
         "@tsconfig/svelte": "^1.0.10",
         "@types/node": "^14.14.44",
-        "obsidian": "https://github.com/obsidianmd/obsidian-api/tarball/master",
+        "obsidian": "^0.12.17",
         "rollup": "^2.47.0",
         "rollup-plugin-svelte": "^7.1.0",
         "svelte-preprocess": "^4.7.3",
@@ -151,6 +154,11 @@
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.44.tgz",
       "integrity": "sha512-+gaugz6Oce6ZInfI/tK4Pq5wIIkJMEJUu92RB3Eu93mtj4wjjjz9EB5mLp5s1pSsLXdC/CPut/xF20ZzAQJbTA==",
       "dev": true
+    },
+    "node_modules/@types/picomatch": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@types/picomatch/-/picomatch-2.3.0.tgz",
+      "integrity": "sha512-O397rnSS9iQI4OirieAtsDqvCj4+3eY1J+EPdNTKuHuRWIfUoGyzX294o8C4KJYaLqgSrd2o60c5EqCU8Zv02g=="
     },
     "node_modules/@types/pug": {
       "version": "2.0.4",
@@ -418,8 +426,9 @@
       }
     },
     "node_modules/obsidian": {
-      "resolved": "https://github.com/obsidianmd/obsidian-api/tarball/master",
-      "integrity": "sha512-09/Zpb7sXE264OLk3DDbieU895d6NaNIIL8eyKR+5WpXPSYKeDfwy4yQh3WSb6KHWTJpbyvqUDchh8Yy4lHiRQ==",
+      "version": "0.12.17",
+      "resolved": "https://registry.npmjs.org/obsidian/-/obsidian-0.12.17.tgz",
+      "integrity": "sha512-YvCAlRym9D8zNPXt6Ez8QubSTVGoChx6lb58zqI13Dcrz3l1lgUO+pcOGDiD5Qa67nzDZLXo3aV2rqkCCpTvGQ==",
       "dev": true,
       "dependencies": {
         "@types/codemirror": "0.0.108",
@@ -445,17 +454,20 @@
       }
     },
     "node_modules/path-parse": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
     },
     "node_modules/picomatch": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
-      "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
+      "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
       "engines": {
         "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/require-relative": {
@@ -705,6 +717,11 @@
       "integrity": "sha512-+gaugz6Oce6ZInfI/tK4Pq5wIIkJMEJUu92RB3Eu93mtj4wjjjz9EB5mLp5s1pSsLXdC/CPut/xF20ZzAQJbTA==",
       "dev": true
     },
+    "@types/picomatch": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@types/picomatch/-/picomatch-2.3.0.tgz",
+      "integrity": "sha512-O397rnSS9iQI4OirieAtsDqvCj4+3eY1J+EPdNTKuHuRWIfUoGyzX294o8C4KJYaLqgSrd2o60c5EqCU8Zv02g=="
+    },
     "@types/pug": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@types/pug/-/pug-2.0.4.tgz",
@@ -938,8 +955,9 @@
       "dev": true
     },
     "obsidian": {
-      "version": "https://github.com/obsidianmd/obsidian-api/tarball/master",
-      "integrity": "sha512-09/Zpb7sXE264OLk3DDbieU895d6NaNIIL8eyKR+5WpXPSYKeDfwy4yQh3WSb6KHWTJpbyvqUDchh8Yy4lHiRQ==",
+      "version": "0.12.17",
+      "resolved": "https://registry.npmjs.org/obsidian/-/obsidian-0.12.17.tgz",
+      "integrity": "sha512-YvCAlRym9D8zNPXt6Ez8QubSTVGoChx6lb58zqI13Dcrz3l1lgUO+pcOGDiD5Qa67nzDZLXo3aV2rqkCCpTvGQ==",
       "dev": true,
       "requires": {
         "@types/codemirror": "0.0.108",
@@ -962,15 +980,15 @@
       "dev": true
     },
     "path-parse": {
-      "version": "1.0.6",
-      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
+      "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
       "dev": true
     },
     "picomatch": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
-      "integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg=="
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
+      "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw=="
     },
     "require-relative": {
       "version": "0.8.7",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@rollup/plugin-typescript": "^6.0.0",
     "@tsconfig/svelte": "^1.0.10",
     "@types/node": "^14.14.44",
-    "obsidian": "https://github.com/obsidianmd/obsidian-api/tarball/master",
+    "obsidian": "^0.12.17",
     "rollup": "^2.47.0",
     "rollup-plugin-svelte": "^7.1.0",
     "svelte-preprocess": "^4.7.3",
@@ -28,6 +28,8 @@
   "dependencies": {
     "@rollup/plugin-json": "^4.1.0",
     "@types/markdown-it": "^12.0.1",
+    "@types/picomatch": "^2.3.0",
+    "picomatch": "^2.3.0",
     "markdown-it": "^12.0.6",
     "svelte": "^3.38.2"
   }

--- a/src/_utils.ts
+++ b/src/_utils.ts
@@ -1,4 +1,5 @@
 import MD from 'markdown-it'
+import picomatch from 'picomatch'
 import {App, CachedMetadata, LinkCache, MarkdownView, MetadataCache, parseFrontMatterTags, TagCache, TFile, Vault} from 'obsidian'
 
 import {LOCAL_SORT_OPT} from './constants'
@@ -22,7 +23,7 @@ export const parseTodos = async (
   const filesWithCache = await Promise.all(
     files
       .filter((file) => {
-        if (ignoreFiles && file.path.includes(ignoreFiles)) return false
+        if (ignoreFiles && picomatch.isMatch(file.path, ignoreFiles)) return false
         if (includeFiles && !file.path.startsWith(includeFiles)) return false
         if (!todoTag) return true
         const fileCache = cache.getFileCache(file)

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -81,7 +81,7 @@ export class TodoSettingTab extends PluginSettingTab {
     new Setting(containerEl)
       .setName("Ignore Files")
       .setDesc(
-        "Ignore files that contain this text anywhere in the filepath. (e.g. 'template' to ignore template.md and templates/file.md)"
+        "Ignore files that match this glob pattern in the filepath. (e.g. 'template*/*' to ignore template.md and templates/file.md)"
       )
       .addText((text) =>
         text.setValue(this.plugin.getSettingValue("ignoreFiles")).onChange(async (value) => {


### PR DESCRIPTION
Got a possible solution for #64 here. Uses [picomatch](https://github.com/micromatch/picomatch) module to allow defining the ignore files field as a [glob](https://github.com/micromatch/picomatch#globbing-features).

This could probably be added to include or combined with include as a `filterFiles` option as well.

With this modification I can put `(*Plan*|Templates)/*` in the `Ignore Files` field and it ignores everything in the `Day Planner` and `Templates` folders.

Side-note, `"obsidian": "^0.12.17",` was changed in package.json as the tarball wouldnt let me run `npm install`