### PR TITLE
Update cache when a file no longer has displayable todos

### DIFF
--- a/src/utils/tasks.ts
+++ b/src/utils/tasks.ts
@@ -25,6 +25,20 @@ import {
 import type { App, LinkCache, MetadataCache, TagCache, TFile, Vault } from "obsidian"
 import type { TodoItem, TagMeta, FileInfo } from "src/_types"
 
+/**
+ * Finds all of the {@link TodoItem todos} in the {@link TFile files} that have been updated since the last re-render.
+ *
+ * @param files The files to search for todos.
+ * @param todoTags The tag(s) that should be present on todos in order to be displayed by this plugin.
+ * @param cache The Obsidian {@link MetadataCache} object.
+ * @param vault The Obsidian {@link Vault} object.
+ * @param includeFiles The pattern of files to include in the search for todos.
+ * @param showChecked Whether the user wants to show completed todos in the plugin's UI.
+ * @param lastRerender Timestamp of the last time we re-rendered the checklist.
+ * @returns A map containing each {@link TFile file} that was updated, and the {@link TodoItem todos} in that file.
+ * If there are no todos in a file, that file will still be present in the map, but the value for its entry will be an
+ * empty array. This is required to account for the case where a file that previously had todos no longer has any.
+ */
 export const parseTodos = async (
   files: TFile[],
   todoTags: string[],
@@ -33,7 +47,7 @@ export const parseTodos = async (
   includeFiles: string,
   showChecked: boolean,
   lastRerender: number
-): Promise<TodoItem[]> => {
+): Promise<Map<TFile, TodoItem[]>> => {
   const includePattern = includeFiles.trim() ? includeFiles.trim().split("\n") : "**/*"
   const filesWithCache = await Promise.all(
     files
@@ -63,11 +77,17 @@ export const parseTodos = async (
         }
       })
   )
-  let allTodos = filesWithCache.flatMap(findAllTodosInFile)
 
-  if (!showChecked) allTodos = allTodos.filter((f) => !f.checked)
+  const todosForUpdatedFiles = new Map<TFile, TodoItem[]>();
+  for (const fileInfo of filesWithCache) {
+    let todos = findAllTodosInFile(fileInfo);
+    if (!showChecked) {
+      todos = todos.filter(todo => !todo.checked);
+    }
+    todosForUpdatedFiles.set(fileInfo.file, todos);
+  }
 
-  return allTodos
+  return todosForUpdatedFiles
 }
 
 export const toggleTodoItem = async (item: TodoItem, app: App) => {

--- a/src/view.ts
+++ b/src/view.ts
@@ -103,7 +103,7 @@ export default class TodoListView extends ItemView {
   }
 
   private async calculateAllItems() {
-    const items = await parseTodos(
+    const todosForUpdatedFiles = await parseTodos(
       this.app.vault.getFiles(),
       this.todoTagArray.length === 0 ? ["*"] : this.visibleTodoTagArray,
       this.app.metadataCache,
@@ -112,12 +112,9 @@ export default class TodoListView extends ItemView {
       this.plugin.getSettingValue("showChecked"),
       this.lastRerender
     )
-    const changesMap = new Map<string, TodoItem[]>()
-    for (const item of items) {
-      if (!changesMap.has(item.filePath)) changesMap.set(item.filePath, [])
-      changesMap.get(item.filePath).push(item)
+    for (const [file, todos] of todosForUpdatedFiles) {
+      this.itemsByFile.set(file.path, todos)
     }
-    for (const [path, pathItems] of changesMap) this.itemsByFile.set(path, pathItems)
   }
 
   private groupItems() {


### PR DESCRIPTION
When the last displayable todo item is completed or otherwise removed
from a file, the item is not removed from the plugin's UI. This is
because the logic for updating the `itemsByFile` cache only considers
files with displayable todos.

To resolve this issue, we need to consider all updated files when
updating the `itemsByFile` cache, regardless of whether they have
displayable todos. We can do this by grouping todos by file when
searching for todos in the `parseTodos` method, then simply updating
`itemsByFile` with each map entry returned by `parseTodos`, even if the
todos list is empty.

GitHub issue #112