### PR TITLE
Fixed the styles to work with 0.16.0 theme

### DIFF
--- a/src/svelte/ChecklistGroup.svelte
+++ b/src/svelte/ChecklistGroup.svelte
@@ -94,6 +94,7 @@
     display: flex;
     padding: var(--checklist-buttonPadding);
     background: transparent;
+    box-shadow: var(--checklist-buttonBoxShadow);
   }
 
   .tag-base {

--- a/src/svelte/ChecklistItem.svelte
+++ b/src/svelte/ChecklistItem.svelte
@@ -60,6 +60,7 @@
   .toggle {
     padding: var(--checklist-togglePadding);
     background: transparent;
+    box-shadow: var(--checklist-listItemBoxShadow);
     flex-shrink: 1;
     width: initial;
   }

--- a/styles.css
+++ b/styles.css
@@ -9,6 +9,7 @@
   --checklist-listItemBackground: var(--interactive-normal);
   --checklist-listItemBackground--hover: var(--interactive-hover);
   --checklist-listItemMargin--compact: 0 0 8px;
+  --checklist-listItemBoxShadow: none;
   --checklist-headerMargin: 0 0 8px;
   --checklist-headerGap: 4px;
   --checklist-headerFontSize: 18px;
@@ -23,6 +24,7 @@
   --checklist-loaderSize: 16px;
   --checklist-loaderBorderColor: var(--text-muted) var(--text-muted) var(--text-normal);
   --checklist-buttonPadding: 0 5px;
+  --checklist-buttonBoxShadow: none;
   --checklist-countPadding: 0 6px;
   --checklist-countBackground: var(--interactive-normal);
   --checklist-countFontSize: 13px;


### PR DESCRIPTION
Obsidian 0.16 looks pretty different! https://forum.obsidian.md/t/obsidian-release-v0-16-0-insider-build/42536

The insider build adds a different default theme, and the default themes make the Checklist Plugin look inconsistent:

<img width="1550" alt="Pasted image 20220914094948" src="https://user-images.githubusercontent.com/1770364/190125758-f67772f9-5a52-44b3-b78f-464caeedd5c0.png">

I removed a couple of box-shadows and here's how it looks like now:

<img width="1310" alt="image" src="https://user-images.githubusercontent.com/1770364/190125937-35966756-f18b-47f9-bc81-12292ebd9b48.png">
